### PR TITLE
Do not modify the gross_unit_price if its already defined

### DIFF
--- a/invoice.py
+++ b/invoice.py
@@ -92,7 +92,8 @@ class InvoiceLine(metaclass=PoolMeta):
             super().on_change_quantity()
         except:
             pass
-        self.gross_unit_price = self.unit_price
+        if not self.gross_unit_price:
+            self.gross_unit_price = self.unit_price
         if not self.discount:
             self.discount = Decimal(0)
         if self.unit_price is not None:

--- a/invoice.py
+++ b/invoice.py
@@ -79,7 +79,8 @@ class InvoiceLine(metaclass=PoolMeta):
     @fields.depends('unit_price', 'discount', methods=['update_prices'])
     def on_change_product(self):
         super().on_change_product()
-        self.gross_unit_price = self.unit_price
+        if not self.gross_unit_price:
+            self.gross_unit_price = self.unit_price
         if not self.discount:
             self.discount = Decimal(0)
 


### PR DESCRIPTION
When you have a discount set on an invoice line, if you start modifying the quantity, the line amount is decreased everytime and will be 0 eventually.

Only needed in 6.8 as this module has been completely updated in greater versions.

It is the same that was discussed here:
<img width="863" height="472" alt="image" src="https://github.com/user-attachments/assets/e9977d90-75f4-4df9-85dd-2e27cce16137" />
But it got introduced on a later commit.